### PR TITLE
Adjust is_login check, compatible with new homeindex profile

### DIFF
--- a/baha.py
+++ b/baha.py
@@ -50,13 +50,21 @@ class Baha():
     def is_login(self) -> bool:
         response = self.reqs.get('https://home.gamer.com.tw/homeindex.php', headers = self.MAIN_HEADERS)
         soup = BeautifulSoup(response.text, 'html.parser')
+        
         ul = soup.find("ul", class_="MSG-mydata1")
         if ul is not None:
             li = ul.find("li")
             web_account = li.find("span").text
             return self.account["uid"] == web_account
-        else:
-            return False
+            
+        div = soup.find("div", class_="header_info-small")
+        if div is not None:
+            import re
+            small = div.find("small")
+            web_account = re.sub(r"^ID：", "", small.text)
+            return self.account["uid"] == web_account
+        return False
+
 
     def signin(self) -> dict:
         signin_status = self.get_signin_status()


### PR DESCRIPTION
新版小屋用來驗證是否登入的的帳號位置不同
![image](https://user-images.githubusercontent.com/241173/171852008-5942f9cb-8a41-4c2a-9b4d-500ddb484e71.png)
由於和舊版對應的 右側的帳號資訊 處理比較麻煩
在這邊採用左上的"ID：account" 比較好處理